### PR TITLE
feat: Implement full ML pipeline with data fetching, training, and GUI

### DIFF
--- a/Fe_materials_dataset.csv
+++ b/Fe_materials_dataset.csv
@@ -1,0 +1,5 @@
+material_id,band_gap_mp,formation_energy_per_atom_mp,is_metal,dos_at_fermi,formula_pretty,num_elements,elements,density_pg,volume_pg,volume_per_atom_pg,spacegroup_number_pg,crystal_system_pg,lattice_a_pg,lattice_b_pg,lattice_c_pg,lattice_alpha_pg,lattice_beta_pg,lattice_gamma_pg,num_sites_pg,target_band_gap,target_formation_energy,target_is_metal,target_dos_at_fermi
+mp-19017,0.0,-4.750,True,2.53,Fe,1,"Fe",7.85,11.79,11.79,229,"cubic",2.86,2.86,2.86,90.0,90.0,90.0,1,0.0,-4.750,True,2.53
+mp-13,0.672,-2.581,False,0.0,FeS2,2,"Fe,S",4.76,38.84,12.95,205,"cubic",5.41,5.41,5.41,90.0,90.0,90.0,3,0.672,-2.581,False,0.0
+mp-22862,0.0,-6.123,True,3.12,Fe3C,2,"C,Fe",7.69,85.20,10.65,62,"orthorhombic",5.09,6.75,4.52,90.0,90.0,90.0,8,0.0,-6.123,True,3.12
+mp-testoxide,1.5,-3.0,False,0.0,Fe2O3,2,"Fe,O",5.24,100.0,20.0,167,"trigonal",5.0,5.0,13.0,90.0,90.0,120.0,10,1.5,-3.0,False,0.0

--- a/README.md
+++ b/README.md
@@ -2,21 +2,52 @@
 
 ## Description
 
-This project is a Tkinter GUI application designed as a prototype for predicting material properties from Crystallographic Information Files (CIF). It allows users to select a CIF file, view some basic extracted material data, and see placeholder predictions for key electronic properties.
+This project is a Tkinter GUI application designed as a prototype for predicting material properties from Crystallographic Information Files (CIF) and for managing a small dataset of materials properties. It allows users to:
+*   Select a CIF file and predict properties using pre-trained machine learning models.
+*   Manually enter material data and save it to a local CSV dataset.
+*   Generate an initial dataset using the Materials Project API (requires an API key).
+*   Train machine learning models based on the generated dataset.
 
-## Current Features
+## Core Components and Workflow
 
-*   **CIF File Selection:** Users can browse and select a `.cif` file from their local system.
-*   **Material Data Extraction:** Utilizes the `pymatgen` library to parse the selected CIF file and extracts:
-    *   Chemical Formula (reduced)
-    *   Density
-    *   Cell Volume
-*   **Placeholder Predictions:** Displays placeholder values for:
-    *   Band Gap
-    *   Density of States (DOS)
-    *   Formation Energy
-    (Note: These predictions are currently based on a hardcoded lookup using the material's chemical formula and are for demonstration purposes only.)
-*   **Error Handling:** Basic error messages are shown if a CIF file cannot be parsed.
+1.  **Data Acquisition (Optional, for dataset generation):**
+    *   Primarily designed for creating a dataset of Fe-based compounds using the Materials Project API.
+    *   **`fetch_mp_data.py`**: This script queries the Materials Project API.
+        *   **Requirement**: You **must** set an environment variable named `MP_API_KEY` with your valid Materials Project API key. You can obtain a key by registering at [materialsproject.org](https://materialsproject.org).
+        *   It fetches raw data for materials containing Iron (Fe) and saves it to `mp_raw_data.json`.
+    *   **`process_raw_data.py`**: This script processes `mp_raw_data.json`.
+        *   It uses `pymatgen` to parse CIF strings and extract structural features.
+        *   It combines these with API-sourced data and saves the result to `Fe_materials_dataset.csv`.
+    *   **Placeholder Dataset**: A placeholder `Fe_materials_dataset.csv` is included in the repository. This allows the GUI and model training script to run for demonstration purposes even if you don't immediately fetch fresh data from the API.
+
+2.  **Model Training (`train_model.py`):**
+    *   This script loads the `Fe_materials_dataset.csv`.
+    *   It trains several machine learning models to predict material properties:
+        *   Band Gap (Regressor)
+        *   Formation Energy per Atom (Regressor)
+        *   Metallicity (Is Metal - Classifier)
+        *   Density of States (DOS) at Fermi Level (Regressor, for metals only)
+    *   The script performs basic preprocessing (imputation, scaling, one-hot encoding) and saves the trained models and preprocessors as `.joblib` files:
+        *   `model_target_band_gap.joblib`
+        *   `model_target_formation_energy.joblib`
+        *   `model_target_is_metal.joblib`
+        *   `model_dos_at_fermi.joblib`
+        *   `preprocessor_main.joblib` (for general features)
+        *   `preprocessor_dos_at_fermi.joblib` (specifically for DOS model features)
+    *   **Usage**: `python train_model.py`
+
+3.  **GUI Application (`material_predictor_gui.py`):**
+    *   A Tkinter-based graphical user interface with two main tabs.
+    *   **"Predict from CIF" Tab:**
+        *   Allows users to select a local CIF file.
+        *   Extracts structural features using `pymatgen`.
+        *   Uses the pre-trained `.joblib` models (loaded on startup) to predict properties: Band Gap, Formation Energy, Metallicity (with confidence score), and DOS at Fermi level (if predicted as metal).
+        *   If any required model/preprocessor is not found (e.g., if `train_model.py` hasn't been run), predictions for those specific properties will show as "N/A (model not loaded)".
+    *   **"Manual Data Entry" Tab:**
+        *   Provides a form to manually input data for all features defined in the project's schema.
+        *   **"Load CIF for Feature Extraction" button:** Allows selecting a CIF file to auto-populate `pymatgen`-derived fields (e.g., formula, density, lattice parameters).
+        *   **"Save to Dataset" button:** Appends the entered data as a new row to `Fe_materials_dataset.csv`. This allows users to augment the dataset or build one if API access is unavailable.
+        *   **"Clear Fields" button:** Resets all entry fields.
 
 ## Setup and Usage
 
@@ -34,13 +65,36 @@ This project is a Tkinter GUI application designed as a prototype for predicting
     ```
 
 3.  **Install dependencies:**
-    Make sure you have Python 3.x installed.
+    Make sure you have Python 3.x installed. The required packages are listed in `requirements.txt`.
     ```bash
     pip install -r requirements.txt
     ```
+    This includes `pymatgen`, `scikit-learn`, `pandas`, `numpy`, `mp-api`, and `joblib`.
 
-4.  **Run the application:**
-    ```bash
-    python material_predictor_gui.py
-    ```
-    This will launch the Tkinter GUI. You can then select a CIF file and click "Predict". Example CIF files are not provided in the repository, so you will need to use your own.
+4.  **Running the Application & Workflow:**
+    *   **Option A: Use placeholder data and pre-trained models (if provided)**
+        1.  The repository may include placeholder `Fe_materials_dataset.csv` and pre-trained `.joblib` files.
+        2.  Run the GUI: `python material_predictor_gui.py`
+        3.  Use the "Predict from CIF" tab with your own CIF files, or explore the "Manual Data Entry" tab.
+    *   **Option B: Generate dataset and train models locally**
+        1.  **Set API Key (Crucial for `fetch_mp_data.py`):**
+            Set the `MP_API_KEY` environment variable:
+            ```bash
+            # Linux/macOS
+            export MP_API_KEY="YOUR_ACTUAL_API_KEY"
+            # Windows Command Prompt
+            set MP_API_KEY="YOUR_ACTUAL_API_KEY"
+            # Windows PowerShell
+            $Env:MP_API_KEY="YOUR_ACTUAL_API_KEY"
+            ```
+        2.  Run data fetching: `python fetch_mp_data.py`
+        3.  Process raw data: `python process_raw_data.py` (This creates/updates `Fe_materials_dataset.csv`)
+        4.  Train models: `python train_model.py` (This creates the `.joblib` model files)
+        5.  Run the GUI: `python material_predictor_gui.py`
+
+## Error Handling & Model Availability
+*   The GUI will show warnings if model files (`.joblib`) are not found during startup, and corresponding predictions will be disabled.
+*   The data fetching script (`fetch_mp_data.py`) will warn if the `MP_API_KEY` is not set and may fail or retrieve limited data.
+*   Basic error messages are shown for CIF parsing issues or missing dataset files.
+
+[end of README.md]

--- a/README_pt.md
+++ b/README_pt.md
@@ -2,21 +2,52 @@
 
 ## Descrição
 
-Este projeto é uma aplicação GUI Tkinter desenhada como um protótipo para prever propriedades de materiais a partir de Arquivos de Informação Cristalográfica (CIF). Ele permite que os usuários selecionem um arquivo CIF, visualizem alguns dados básicos extraídos do material e vejam previsões de placeholder para propriedades eletrônicas chave.
+Este projeto é uma aplicação GUI Tkinter desenhada como um protótipo para prever propriedades de materiais a partir de Arquivos de Informação Cristalográfica (CIF) e para gerenciar um pequeno conjunto de dados de propriedades de materiais. Ele permite aos usuários:
+*   Selecionar um arquivo CIF e prever propriedades usando modelos de machine learning pré-treinados.
+*   Inserir manualmente dados de materiais e salvá-los em um conjunto de dados CSV local.
+*   Gerar um conjunto de dados inicial usando a API do Materials Project (requer uma chave de API).
+*   Treinar modelos de machine learning com base no conjunto de dados gerado.
 
-## Funcionalidades Atuais
+## Componentes Principais e Fluxo de Trabalho
 
-*   **Seleção de Arquivo CIF:** Usuários podem navegar e selecionar um arquivo `.cif` do seu sistema local.
-*   **Extração de Dados do Material:** Utiliza a biblioteca `pymatgen` para analisar o arquivo CIF selecionado e extrai:
-    *   Fórmula Química (reduzida)
-    *   Densidade
-    *   Volume da Célula Unitária
-*   **Previsões Placeholder:** Exibe valores placeholder para:
-    *   Gap de Energia (Band Gap)
-    *   Densidade de Estados (DOS)
-    *   Energia de Formação
-    (Observação: Estas previsões são atualmente baseadas em uma consulta a dados pré-definidos usando a fórmula química do material e são apenas para fins de demonstração.)
-*   **Tratamento de Erros:** Mensagens de erro básicas são exibidas se um arquivo CIF não puder ser analisado.
+1.  **Aquisição de Dados (Opcional, para geração do conjunto de dados):**
+    *   Projetado primariamente para criar um conjunto de dados de compostos baseados em Ferro (Fe) usando a API do Materials Project.
+    *   **`fetch_mp_data.py`**: Este script consulta a API do Materials Project.
+        *   **Requisito**: Você **deve** definir uma variável de ambiente chamada `MP_API_KEY` com sua chave de API válida do Materials Project. Você pode obter uma chave registrando-se em [materialsproject.org](https://materialsproject.org).
+        *   Ele busca dados brutos para materiais contendo Ferro (Fe) e os salva em `mp_raw_data.json`.
+    *   **`process_raw_data.py`**: Este script processa o `mp_raw_data.json`.
+        *   Ele usa `pymatgen` para analisar strings CIF e extrair características estruturais.
+        *   Combina essas características com dados obtidos da API e salva o resultado em `Fe_materials_dataset.csv`.
+    *   **Conjunto de Dados Placeholder**: Um arquivo `Fe_materials_dataset.csv` de exemplo está incluído no repositório. Isso permite que a GUI e o script de treinamento de modelos funcionem para fins de demonstração, mesmo que você não busque dados novos da API imediatamente.
+
+2.  **Treinamento de Modelos (`train_model.py`):**
+    *   Este script carrega o `Fe_materials_dataset.csv`.
+    *   Ele treina vários modelos de machine learning para prever propriedades de materiais:
+        *   Gap de Energia (Band Gap - Regressor)
+        *   Energia de Formação por Átomo (Regressor)
+        *   Metalicidade (É Metal - Classificador)
+        *   Densidade de Estados (DOS) no Nível de Fermi (Regressor, apenas para metais)
+    *   O script realiza pré-processamento básico (imputação, escalonamento, one-hot encoding) e salva os modelos treinados e os pré-processadores como arquivos `.joblib`:
+        *   `model_target_band_gap.joblib`
+        *   `model_target_formation_energy.joblib`
+        *   `model_target_is_metal.joblib`
+        *   `model_dos_at_fermi.joblib`
+        *   `preprocessor_main.joblib` (para características gerais)
+        *   `preprocessor_dos_at_fermi.joblib` (especificamente para características do modelo DOS)
+    *   **Uso**: `python train_model.py`
+
+3.  **Aplicação GUI (`material_predictor_gui.py`):**
+    *   Uma interface gráfica de usuário baseada em Tkinter com duas abas principais.
+    *   **Aba "Prever a partir de CIF":**
+        *   Permite aos usuários selecionar um arquivo CIF local.
+        *   Extrai características estruturais usando `pymatgen`.
+        *   Usa os modelos `.joblib` pré-treinados (carregados na inicialização) para prever propriedades: Gap de Energia, Energia de Formação, Metalicidade (com pontuação de confiança) e DOS no Nível de Fermi (se previsto como metal).
+        *   Se algum modelo/pré-processador necessário não for encontrado (ex.: se `train_model.py` não foi executado), as previsões para essas propriedades específicas aparecerão como "N/A (modelo não carregado)".
+    *   **Aba "Entrada Manual de Dados":**
+        *   Fornece um formulário para inserir manualmente dados para todas as características definidas no esquema do projeto.
+        *   Botão **"Carregar CIF para Extração de Características"**: Permite selecionar um arquivo CIF para preencher automaticamente os campos derivados pelo `pymatgen` (ex.: fórmula, densidade, parâmetros de rede).
+        *   Botão **"Salvar no Conjunto de Dados"**: Adiciona os dados inseridos como uma nova linha ao `Fe_materials_dataset.csv`. Isso permite aos usuários aumentar o conjunto de dados ou construir um se o acesso à API não estiver disponível.
+        *   Botão **"Limpar Campos"**: Reinicia todos os campos de entrada.
 
 ## Configuração e Uso
 
@@ -34,13 +65,36 @@ Este projeto é uma aplicação GUI Tkinter desenhada como um protótipo para pr
     ```
 
 3.  **Instale as dependências:**
-    Certifique-se de que você tem o Python 3.x instalado.
+    Certifique-se de que você tem o Python 3.x instalado. Os pacotes necessários estão listados em `requirements.txt`.
     ```bash
     pip install -r requirements.txt
     ```
+    Isso inclui `pymatgen`, `scikit-learn`, `pandas`, `numpy`, `mp-api` e `joblib`.
 
-4.  **Execute a aplicação:**
-    ```bash
-    python material_predictor_gui.py
-    ```
-    Isso iniciará a GUI Tkinter. Você poderá então selecionar um arquivo CIF e clicar em "Prever". Arquivos CIF de exemplo não são fornecidos no repositório, então você precisará usar os seus próprios.
+4.  **Executando a Aplicação e Fluxo de Trabalho:**
+    *   **Opção A: Usar dados de exemplo e modelos pré-treinados (se fornecidos)**
+        1.  O repositório pode incluir um `Fe_materials_dataset.csv` de exemplo e arquivos `.joblib` pré-treinados.
+        2.  Execute a GUI: `python material_predictor_gui.py`
+        3.  Use a aba "Prever a partir de CIF" com seus próprios arquivos CIF ou explore a aba "Entrada Manual de Dados".
+    *   **Opção B: Gerar conjunto de dados e treinar modelos localmente**
+        1.  **Defina a Chave de API (Crucial para `fetch_mp_data.py`):**
+            Defina a variável de ambiente `MP_API_KEY`:
+            ```bash
+            # Linux/macOS
+            export MP_API_KEY="SUA_CHAVE_DE_API_REAL"
+            # Windows Command Prompt
+            set MP_API_KEY="SUA_CHAVE_DE_API_REAL"
+            # Windows PowerShell
+            $Env:MP_API_KEY="SUA_CHAVE_DE_API_REAL"
+            ```
+        2.  Execute a busca de dados: `python fetch_mp_data.py`
+        3.  Processe os dados brutos: `python process_raw_data.py` (Isso cria/atualiza `Fe_materials_dataset.csv`)
+        4.  Treine os modelos: `python train_model.py` (Isso cria os arquivos de modelo `.joblib`)
+        5.  Execute a GUI: `python material_predictor_gui.py`
+
+## Tratamento de Erros e Disponibilidade dos Modelos
+*   A GUI exibirá avisos se os arquivos de modelo (`.joblib`) não forem encontrados durante a inicialização, e as previsões correspondentes serão desabilitadas.
+*   O script de busca de dados (`fetch_mp_data.py`) avisará se a `MP_API_KEY` não estiver definida e poderá falhar ou recuperar dados limitados.
+*   Mensagens de erro básicas são exibidas para problemas de análise de CIF ou arquivos de conjunto de dados ausentes.
+
+[end of README_pt.md]

--- a/fetch_mp_data.py
+++ b/fetch_mp_data.py
@@ -1,0 +1,151 @@
+import os
+import json
+import warnings
+from mp_api.client import MPRester
+from pymatgen.core import Composition, Structure # Ensure Structure is imported
+
+# DATA_SCHEMA definition remains the same
+DATA_SCHEMA = {
+    "material_id": "Materials Project ID (e.g., mp-123)",
+    "cif_string": "Crystallographic Information File as a string",
+    "band_gap_mp": "Band Gap (eV) directly from MP",
+    "formation_energy_per_atom_mp": "Formation Energy (eV/atom) directly from MP",
+    "dos_object_mp": "The CompleteDOS object from MP (temporary, for processing)",
+    "is_metal": "Boolean (True if band_gap_mp == 0, False otherwise)",
+    "dos_at_fermi": "Value of total DOS at Fermi level (eV⁻¹). 0 or N/A for insulators.",
+    "formula_pretty": "Reduced chemical formula (e.g., 'Si', 'GaAs')",
+    "num_elements": "Number of distinct elements in the material",
+    "elements": "Comma-separated string of elements (e.g., 'Ga,As')",
+    "density_pg": "Density (g/cm³) calculated by pymatgen",
+    "volume_pg": "Cell Volume (Å³) calculated by pymatgen",
+    "volume_per_atom_pg": "Volume per atom (Å³/atom) calculated by pymatgen",
+    "spacegroup_number_pg": "Space Group Number calculated by pymatgen",
+    "crystal_system_pg": "Crystal System (e.g., 'cubic', 'tetragonal') from pymatgen",
+    "lattice_a_pg": "Lattice parameter a (Å)",
+    "lattice_b_pg": "Lattice parameter b (Å)",
+    "lattice_c_pg": "Lattice parameter c (Å)",
+    "lattice_alpha_pg": "Lattice angle alpha (°)",
+    "lattice_beta_pg": "Lattice angle beta (°)",
+    "lattice_gamma_pg": "Lattice angle gamma (°)",
+    "num_sites_pg": "Number of atomic sites in the unit cell from pymatgen",
+    "target_band_gap": "Final Band Gap (eV) for ML",
+    "target_formation_energy": "Final Formation Energy (eV/atom) for ML",
+    "target_is_metal": "Final 'is_metal' boolean for ML",
+    "target_dos_at_fermi": "Final 'dos_at_fermi' for ML"
+}
+
+def fetch_data(max_total_materials=50):
+    api_key = os.environ.get("MP_API_KEY")
+    if api_key is None:
+        warnings.warn("MP_API_KEY environment variable not set. Proceeding with anonymous access.")
+
+    raw_materials_data = []
+
+    # Fields for the initial summary search
+    summary_fields = [
+        "material_id", "formula_pretty", "nelements",
+        "band_gap", "formation_energy_per_atom"
+    ]
+
+    # Define criteria sets for different numbers of elements for Python-side filtering
+    criteria_sets = [
+        {"target_n_elements": 2, "limit_per_set": 20, "description": "binary Fe compounds"},
+        {"target_n_elements": 3, "limit_per_set": 20, "description": "ternary Fe compounds"},
+        {"target_n_elements": 4, "limit_per_set": 10, "description": "quaternary Fe compounds"},
+        {"target_n_elements": 1, "limit_per_set": 5, "description": "elemental Fe"},
+    ]
+
+    # Cache for initial summary query results
+    summary_docs_cache = None
+
+    with MPRester(api_key=api_key) as mpr:
+        print("Fetching initial candidate materials (Fe-containing with band_gap data)...")
+        try:
+            # Step 1: Initial query using summary.search
+            # Query for Fe-containing materials that have a band_gap calculated (0 to 100 eV is a wide range)
+            # The mp-api client handles pagination by default. Default limit is 1000.
+            summary_docs_cache = mpr.materials.summary.search(
+                elements=["Fe"],
+                band_gap=(0, 100), # Filter for materials with calculated band gaps
+                fields=summary_fields
+            )
+            if not summary_docs_cache:
+                summary_docs_cache = [] # Ensure it's an empty list if None
+            print(f"Found {len(summary_docs_cache)} initial Fe-containing candidates with band gap data.")
+        except Exception as e:
+            warnings.warn(f"API call for initial summary search failed: {e}")
+            summary_docs_cache = [] # Ensure it's an empty list on failure
+
+        if not summary_docs_cache:
+            print("No initial candidate materials found. Exiting.")
+            return
+
+        # Step 2: Iterate through criteria sets, filter candidates, and fetch details
+        for criteria_set in criteria_sets:
+            if len(raw_materials_data) >= max_total_materials:
+                print(f"Reached overall target of {len(raw_materials_data)}/{max_total_materials} materials. Stopping.")
+                break
+
+            target_n_elements = criteria_set["target_n_elements"]
+            limit_per_set = criteria_set["limit_per_set"]
+            description = criteria_set["description"]
+
+            print(f"\nProcessing for {description} (target {target_n_elements} elements)...")
+
+            materials_added_this_set = 0
+            for summary_doc in summary_docs_cache:
+                if len(raw_materials_data) >= max_total_materials: break
+                if materials_added_this_set >= limit_per_set: break
+
+                # Python-side filtering for number of elements
+                num_doc_elements = summary_doc.nelements if hasattr(summary_doc, 'nelements') and summary_doc.nelements is not None \
+                                   else len(Composition(summary_doc.formula_pretty).elements)
+
+                if num_doc_elements != target_n_elements:
+                    continue
+
+                material_id = str(summary_doc.material_id)
+                print(f"  Fetching details for {material_id} ({summary_doc.formula_pretty})...")
+
+                try:
+                    # Fetch structure
+                    structure = mpr.get_structure_by_material_id(material_id)
+                    cif_string = structure.to(fmt="cif") if structure else None
+
+                    # Fetch DOS
+                    dos = mpr.get_dos_by_material_id(material_id)
+                    dos_dict = dos.as_dict() if dos else None
+
+                    material_entry = {
+                        "material_id": material_id,
+                        "cif_string": cif_string,
+                        "band_gap_mp": summary_doc.band_gap,
+                        "formation_energy_per_atom_mp": summary_doc.formation_energy_per_atom,
+                        "dos_object_mp": dos_dict,
+                        "formula_pretty_mp": summary_doc.formula_pretty,
+                        "nelements_mp": num_doc_elements
+                    }
+                    raw_materials_data.append(material_entry)
+                    materials_added_this_set += 1
+
+                except Exception as e:
+                    warnings.warn(f"  Failed to fetch details for {material_id}: {e}")
+
+            print(f"Added {materials_added_this_set} materials for {description}. Total collected: {len(raw_materials_data)}")
+
+    print(f"\nTotal materials collected after all processing: {len(raw_materials_data)}")
+
+    if raw_materials_data:
+        filename = "mp_raw_data.json"
+        print(f"Saving raw data to {filename}...")
+        try:
+            with open(filename, 'w') as f:
+                json.dump(raw_materials_data, f, indent=4)
+            print(f"Successfully saved data for {len(raw_materials_data)} materials to {filename}.")
+        except Exception as e:
+            print(f"Error saving data to JSON: {e}")
+    else:
+        print("No data collected to save.")
+
+if __name__ == "__main__":
+    fetch_data(max_total_materials=50)

--- a/material_predictor_gui.py
+++ b/material_predictor_gui.py
@@ -1,147 +1,518 @@
 import tkinter as tk
+from tkinter import ttk # Import ttk
 from tkinter import filedialog
-from tkinter import messagebox # Ensure messagebox is imported
-from pymatgen.core import Structure # Import Structure
+from tkinter import messagebox
+from pymatgen.core import Structure
+import csv
+import os
+import joblib
+import pandas as pd
+import numpy as np
+
+# DATA_SCHEMA (consistent with Fe_materials_dataset.csv structure)
+# This helps in defining fields and saving data.
+CSV_HEADERS = [
+    "material_id", "band_gap_mp", "formation_energy_per_atom_mp", "is_metal", "dos_at_fermi",
+    "formula_pretty", "num_elements", "elements", "density_pg", "volume_pg", "volume_per_atom_pg",
+    "spacegroup_number_pg", "crystal_system_pg", "lattice_a_pg", "lattice_b_pg", "lattice_c_pg",
+    "lattice_alpha_pg", "lattice_beta_pg", "lattice_gamma_pg", "num_sites_pg",
+    "target_band_gap", "target_formation_energy", "target_is_metal", "target_dos_at_fermi"
+]
 
 class Application(tk.Tk):
     def __init__(self):
         super().__init__()
         self.title("Material Property Predictor Prototype")
+        self.geometry("900x700") # Adjusted size for more content
+
+        # Tabbed interface
+        self.notebook = ttk.Notebook(self)
+        self.notebook.pack(expand=True, fill='both', padx=10, pady=10)
+
+        # --- Prediction Tab (existing functionality) ---
+        self.prediction_tab = ttk.Frame(self.notebook)
+        self.notebook.add(self.prediction_tab, text='Predict from CIF')
+        self.setup_prediction_tab()
+
+        # --- Manual Data Entry Tab ---
+        self.manual_entry_tab = ttk.Frame(self.notebook)
+        self.notebook.add(self.manual_entry_tab, text='Manual Data Entry')
+        self.manual_entry_fields = {} # To store Entry/Combobox widgets
+        self.setup_manual_entry_tab()
+
+        self.selected_manual_cif_path = tk.StringVar()
+
+        # Load models and preprocessors
+        self.load_models()
+
+
+    def load_models(self):
+        print("Loading models and preprocessors...")
+        models_to_load = {
+            "preprocessor_main": "preprocessor_main.joblib",
+            "preprocessor_dos": "preprocessor_dos_at_fermi.joblib", # Corrected key for consistency
+            "model_band_gap": "model_target_band_gap.joblib",
+            "model_formation_energy": "model_target_formation_energy.joblib",
+            "model_is_metal": "model_target_is_metal.joblib",
+            "model_dos_at_fermi": "model_dos_at_fermi.joblib"
+        }
+        for attr_name, filename in models_to_load.items():
+            try:
+                setattr(self, attr_name, joblib.load(filename))
+                print(f"Successfully loaded {filename} as self.{attr_name}")
+            except FileNotFoundError:
+                warnings.warn(f"Warning: {filename} not found. Predictions using this will be unavailable.")
+                setattr(self, attr_name, None)
+            except Exception as e:
+                warnings.warn(f"Warning: Error loading {filename}: {e}. Predictions using this will be unavailable.")
+                setattr(self, attr_name, None)
+
+
+    def setup_prediction_tab(self):
+        # Existing prediction functionality widgets moved here
         self.selected_file_path = ""
-        self.current_structure = None # To store the parsed pymatgen structure
-        self.extracted_formula = "N/A"
-        self.extracted_density = "N/A"
-        self.extracted_volume = "N/A"
+        self.current_structure = None
+        # These _extracted_ variables are for pymatgen direct values, not model predictions
+        # self.extracted_formula = "N/A"
+        # self.extracted_density = "N/A"
+        # self.extracted_volume = "N/A"
 
-        # Optionally set window size
-        # self.geometry("800x600")
+        select_button = ttk.Button(self.prediction_tab, text="Select CIF File", command=self.select_file_for_prediction)
+        select_button.pack(pady=10)
 
-        self.select_button = tk.Button(self, text="Select CIF File", command=self.select_file)
-        self.select_button.pack(pady=10)
-
-        self.file_label = tk.Label(self, text="No file selected")
+        self.file_label = ttk.Label(self.prediction_tab, text="No file selected")
         self.file_label.pack(pady=5)
 
-        self.predict_button = tk.Button(self, text="Predict", command=self.perform_prediction)
-        self.predict_button.pack(pady=10)
+        predict_button = ttk.Button(self.prediction_tab, text="Predict Properties", command=self.perform_prediction)
+        predict_button.pack(pady=10)
 
-        # Labels for displaying predictions
-        self.band_gap_label_title = tk.Label(self, text="Band Gap:")
-        self.band_gap_label_title.pack()
-        self.band_gap_label_value = tk.Label(self, text="N/A")
-        self.band_gap_label_value.pack()
+        results_frame = ttk.LabelFrame(self.prediction_tab, text="Prediction Results")
+        results_frame.pack(padx=10, pady=10, fill="x", expand=True)
 
-        self.dos_label_title = tk.Label(self, text="DOS:")
-        self.dos_label_title.pack()
-        self.dos_label_value = tk.Label(self, text="N/A")
-        self.dos_label_value.pack()
+        # Pymatgen Extracted Features Display
+        pg_features_frame = ttk.LabelFrame(results_frame, text="Pymatgen-Derived Features")
+        pg_features_frame.pack(padx=5, pady=5, fill="x", expand=True)
+        self.formula_label_value = self._create_display_label(pg_features_frame, "Chemical Formula:")
+        self.density_label_value = self._create_display_label(pg_features_frame, "Density:")
+        self.volume_label_value = self._create_display_label(pg_features_frame, "Cell Volume:")
 
-        self.formation_energy_label_title = tk.Label(self, text="Formation Energy:")
-        self.formation_energy_label_title.pack()
-        self.formation_energy_label_value = tk.Label(self, text="N/A")
-        self.formation_energy_label_value.pack(pady=(0,5))
-
-        # Labels for pymatgen-derived properties
-        self.formula_label_title = tk.Label(self, text="Chemical Formula:")
-        self.formula_label_title.pack()
-        self.formula_label_value = tk.Label(self, text="N/A")
-        self.formula_label_value.pack()
-
-        self.density_label_title = tk.Label(self, text="Density:")
-        self.density_label_title.pack()
-        self.density_label_value = tk.Label(self, text="N/A")
-        self.density_label_value.pack()
-
-        self.volume_label_title = tk.Label(self, text="Cell Volume:")
-        self.volume_label_title.pack()
-        self.volume_label_value = tk.Label(self, text="N/A")
-        self.volume_label_value.pack()
+        # Model Predictions Display
+        model_preds_frame = ttk.LabelFrame(results_frame, text="Model Predictions")
+        model_preds_frame.pack(padx=5, pady=5, fill="x", expand=True)
+        self.model_is_metal_label = self._create_display_label(model_preds_frame, "Is Metal:")
+        self.model_band_gap_label = self._create_display_label(model_preds_frame, "Band Gap (Model):")
+        self.model_formation_energy_label = self._create_display_label(model_preds_frame, "Formation Energy (Model):")
+        self.model_dos_at_fermi_label = self._create_display_label(model_preds_frame, "DOS at Fermi (Model):")
 
 
-    def select_file(self):
+    def _create_display_label(self, parent, text):
+        frame = ttk.Frame(parent)
+        frame.pack(fill='x', padx=5, pady=2) # Added padx
+        ttk.Label(frame, text=text, width=25, anchor='w').pack(side=tk.LEFT) # Fixed width for title
+        value_label = ttk.Label(frame, text="N/A", anchor='w') # Dynamic width for value
+        value_label.pack(side=tk.LEFT, fill='x', expand=True)
+        return value_label
+
+    def setup_manual_entry_tab(self):
+        # Scrollable Frame Setup
+        canvas = tk.Canvas(self.manual_entry_tab)
+        scrollbar = ttk.Scrollbar(self.manual_entry_tab, orient="vertical", command=canvas.yview)
+        scrollable_frame = ttk.Frame(canvas)
+
+        scrollable_frame.bind(
+            "<Configure>",
+            lambda e: canvas.configure(scrollregion=canvas.bbox("all"))
+        )
+        canvas.create_window((0, 0), window=scrollable_frame, anchor="nw")
+        canvas.configure(yscrollcommand=scrollbar.set)
+
+        canvas.pack(side="left", fill="both", expand=True)
+        scrollbar.pack(side="right", fill="y")
+
+        # --- Labelframes for sections ---
+        # Identifier Section
+        id_frame = ttk.LabelFrame(scrollable_frame, text="Identifier")
+        id_frame.pack(padx=10, pady=5, fill="x")
+        self._add_manual_entry_field(id_frame, "material_id", "Material ID*:", CSV_HEADERS[0])
+
+        # Load CIF Section
+        load_cif_frame = ttk.LabelFrame(scrollable_frame, text="Load CIF for Feature Extraction")
+        load_cif_frame.pack(padx=10, pady=5, fill="x")
+        ttk.Button(load_cif_frame, text="Load CIF File", command=self.load_cif_for_manual_entry).pack(side=tk.LEFT, padx=5, pady=5)
+        self.manual_cif_path_label = ttk.Label(load_cif_frame, text="No CIF file loaded.")
+        self.manual_cif_path_label.pack(side=tk.LEFT, padx=5, pady=5, fill='x', expand=True)
+
+
+        # Pymatgen-Derived Features
+        pg_frame = ttk.LabelFrame(scrollable_frame, text="Pymatgen-Derived Features (auto-filled from CIF or manual)")
+        pg_frame.pack(padx=10, pady=5, fill="x")
+        self._add_manual_entry_field(pg_frame, "formula_pretty", "Formula (Pretty):", CSV_HEADERS[5])
+        self._add_manual_entry_field(pg_frame, "num_elements", "Number of Elements:", CSV_HEADERS[6], entry_type='number')
+        self._add_manual_entry_field(pg_frame, "elements", "Elements (comma-sep, sorted):", CSV_HEADERS[7])
+        self._add_manual_entry_field(pg_frame, "density_pg", "Density (g/cm³):", CSV_HEADERS[8], entry_type='number')
+        self._add_manual_entry_field(pg_frame, "volume_pg", "Cell Volume (Å³):", CSV_HEADERS[9], entry_type='number')
+        self._add_manual_entry_field(pg_frame, "volume_per_atom_pg", "Volume per Atom (Å³/atom):", CSV_HEADERS[10], entry_type='number')
+        self._add_manual_entry_field(pg_frame, "spacegroup_number_pg", "Space Group Number:", CSV_HEADERS[11], entry_type='number')
+        crystal_systems = ['triclinic', 'monoclinic', 'orthorhombic', 'tetragonal', 'trigonal', 'hexagonal', 'cubic', 'N/A']
+        self._add_manual_entry_field(pg_frame, "crystal_system_pg", "Crystal System:", CSV_HEADERS[12], options=crystal_systems)
+        self._add_manual_entry_field(pg_frame, "lattice_a_pg", "Lattice a (Å):", CSV_HEADERS[13], entry_type='number')
+        self._add_manual_entry_field(pg_frame, "lattice_b_pg", "Lattice b (Å):", CSV_HEADERS[14], entry_type='number')
+        self._add_manual_entry_field(pg_frame, "lattice_c_pg", "Lattice c (Å):", CSV_HEADERS[15], entry_type='number')
+        self._add_manual_entry_field(pg_frame, "lattice_alpha_pg", "Lattice α (°):", CSV_HEADERS[16], entry_type='number')
+        self._add_manual_entry_field(pg_frame, "lattice_beta_pg", "Lattice β (°):", CSV_HEADERS[17], entry_type='number')
+        self._add_manual_entry_field(pg_frame, "lattice_gamma_pg", "Lattice γ (°):", CSV_HEADERS[18], entry_type='number')
+        self._add_manual_entry_field(pg_frame, "num_sites_pg", "Number of Sites:", CSV_HEADERS[19], entry_type='number')
+
+        # Externally Sourced / MP Features
+        mp_frame = ttk.LabelFrame(scrollable_frame, text="Externally Sourced Properties (e.g., from Materials Project)")
+        mp_frame.pack(padx=10, pady=5, fill="x")
+        self._add_manual_entry_field(mp_frame, "band_gap_mp", "Band Gap (MP, eV):", CSV_HEADERS[1], entry_type='number')
+        self._add_manual_entry_field(mp_frame, "formation_energy_per_atom_mp", "Formation Energy (MP, eV/atom):", CSV_HEADERS[2], entry_type='number')
+        self._add_manual_entry_field(mp_frame, "is_metal", "Is Metal (MP):", CSV_HEADERS[3], options=["True", "False", "N/A"])
+        self._add_manual_entry_field(mp_frame, "dos_at_fermi", "DOS at Fermi (MP, eV⁻¹):", CSV_HEADERS[4], entry_type='number')
+
+        # Target Properties
+        target_frame = ttk.LabelFrame(scrollable_frame, text="Target Properties (for ML model training)")
+        target_frame.pack(padx=10, pady=5, fill="x")
+        self._add_manual_entry_field(target_frame, "target_band_gap", "Target Band Gap (eV)*:", CSV_HEADERS[20], entry_type='number')
+        self._add_manual_entry_field(target_frame, "target_formation_energy", "Target Formation Energy (eV/atom)*:", CSV_HEADERS[21], entry_type='number')
+        self._add_manual_entry_field(target_frame, "target_is_metal", "Target Is Metal*:", CSV_HEADERS[22], options=["True", "False", "N/A"])
+        self._add_manual_entry_field(target_frame, "target_dos_at_fermi", "Target DOS at Fermi (eV⁻¹):", CSV_HEADERS[23], entry_type='number')
+
+        # Action Buttons
+        action_frame = ttk.Frame(scrollable_frame)
+        action_frame.pack(padx=10, pady=10, fill="x")
+        ttk.Button(action_frame, text="Save to Dataset", command=self.save_manual_entry).pack(side=tk.LEFT, padx=5)
+        ttk.Button(action_frame, text="Clear Fields", command=self.clear_manual_entry_fields).pack(side=tk.LEFT, padx=5)
+
+    def _add_manual_entry_field(self, parent, key_name, label_text, schema_key_ref, options=None, entry_type='text'):
+        # schema_key_ref is mostly for reference here, actual key is key_name
+        frame = ttk.Frame(parent)
+        frame.pack(fill="x", padx=5, pady=2)
+        ttk.Label(frame, text=label_text, width=30).pack(side=tk.LEFT)
+
+        if options:
+            widget = ttk.Combobox(frame, values=options, width=37)
+            if "N/A" in options: widget.set("N/A")
+            elif options: widget.set(options[0])
+        else:
+            widget = ttk.Entry(frame, width=40)
+
+        widget.pack(side=tk.LEFT, fill="x", expand=True)
+        self.manual_entry_fields[key_name] = widget
+
+    def load_cif_for_manual_entry(self):
+        filepath = filedialog.askopenfilename(
+            title="Select CIF File",
+            filetypes=[("CIF files", "*.cif"), ("All files", "*.*")]
+        )
+        if not filepath:
+            return
+
+        self.selected_manual_cif_path.set(filepath)
+        self.manual_cif_path_label.config(text=os.path.basename(filepath))
+
+        try:
+            struct = Structure.from_file(filepath)
+
+            # Auto-fill pymatgen fields
+            self.manual_entry_fields['formula_pretty'].delete(0, tk.END)
+            self.manual_entry_fields['formula_pretty'].insert(0, struct.composition.reduced_formula)
+
+            self.manual_entry_fields['num_elements'].delete(0, tk.END)
+            self.manual_entry_fields['num_elements'].insert(0, str(len(struct.composition.elements)))
+
+            self.manual_entry_fields['elements'].delete(0, tk.END)
+            self.manual_entry_fields['elements'].insert(0, ','.join(sorted([el.symbol for el in struct.composition.elements])))
+
+            self.manual_entry_fields['density_pg'].delete(0, tk.END)
+            self.manual_entry_fields['density_pg'].insert(0, f"{struct.density:.4f}")
+
+            self.manual_entry_fields['volume_pg'].delete(0, tk.END)
+            self.manual_entry_fields['volume_pg'].insert(0, f"{struct.volume:.4f}")
+
+            self.manual_entry_fields['volume_per_atom_pg'].delete(0, tk.END)
+            self.manual_entry_fields['volume_per_atom_pg'].insert(0, f"{struct.volume / struct.num_sites:.4f}")
+
+            self.manual_entry_fields['spacegroup_number_pg'].delete(0, tk.END)
+            self.manual_entry_fields['spacegroup_number_pg'].insert(0, str(struct.get_space_group_info()[1]))
+
+            self.manual_entry_fields['crystal_system_pg'].set(struct.get_crystal_system())
+
+            lat = struct.lattice
+            for param_key, param_val in zip(
+                ['lattice_a_pg', 'lattice_b_pg', 'lattice_c_pg', 'lattice_alpha_pg', 'lattice_beta_pg', 'lattice_gamma_pg'],
+                [lat.a, lat.b, lat.c, lat.alpha, lat.beta, lat.gamma]
+            ):
+                self.manual_entry_fields[param_key].delete(0, tk.END)
+                self.manual_entry_fields[param_key].insert(0, f"{param_val:.4f}")
+
+            self.manual_entry_fields['num_sites_pg'].delete(0, tk.END)
+            self.manual_entry_fields['num_sites_pg'].insert(0, str(struct.num_sites))
+
+            messagebox.showinfo("CIF Loaded", "Pymatgen-derived features have been auto-filled.")
+
+        except Exception as e:
+            messagebox.showerror("CIF Parsing Error", f"Could not read or parse CIF file: {e}")
+            self.manual_cif_path_label.config(text="CIF loading failed.")
+
+
+    def save_manual_entry(self):
+        data_row = {}
+        try:
+            # Validate and collect data
+            # Identifier (required)
+            material_id = self.manual_entry_fields['material_id'].get()
+            if not material_id.strip():
+                messagebox.showerror("Validation Error", "Material ID is required.")
+                return
+            data_row['material_id'] = material_id.strip()
+
+            # Pymatgen features
+            for key in ["formula_pretty", "elements", "crystal_system_pg"]: # String/Combobox
+                 data_row[key] = self.manual_entry_fields[key].get()
+
+            pg_numeric_keys = [
+                "num_elements", "density_pg", "volume_pg", "volume_per_atom_pg", "spacegroup_number_pg",
+                "lattice_a_pg", "lattice_b_pg", "lattice_c_pg", "lattice_alpha_pg", "lattice_beta_pg",
+                "lattice_gamma_pg", "num_sites_pg"
+            ]
+            for key in pg_numeric_keys:
+                val_str = self.manual_entry_fields[key].get()
+                data_row[key] = float(val_str) if val_str else '' # Allow empty for non-required
+
+            # Externally Sourced / MP Features
+            mp_numeric_keys = ["band_gap_mp", "formation_energy_per_atom_mp", "dos_at_fermi"]
+            for key in mp_numeric_keys:
+                val_str = self.manual_entry_fields[key].get()
+                data_row[key] = float(val_str) if val_str else ''
+
+            is_metal_val = self.manual_entry_fields['is_metal'].get()
+            data_row['is_metal'] = is_metal_val if is_metal_val != "N/A" else ''
+
+
+            # Target Properties (validate required ones)
+            target_band_gap_str = self.manual_entry_fields['target_band_gap'].get()
+            if not target_band_gap_str: messagebox.showerror("Validation Error", "Target Band Gap is required."); return
+            data_row['target_band_gap'] = float(target_band_gap_str)
+
+            target_formation_energy_str = self.manual_entry_fields['target_formation_energy'].get()
+            if not target_formation_energy_str: messagebox.showerror("Validation Error", "Target Formation Energy is required."); return
+            data_row['target_formation_energy'] = float(target_formation_energy_str)
+
+            target_is_metal_val = self.manual_entry_fields['target_is_metal'].get()
+            if not target_is_metal_val or target_is_metal_val == "N/A": messagebox.showerror("Validation Error", "Target Is Metal is required."); return
+            data_row['target_is_metal'] = target_is_metal_val
+
+            target_dos_str = self.manual_entry_fields['target_dos_at_fermi'].get()
+            data_row['target_dos_at_fermi'] = float(target_dos_str) if target_dos_str else ''
+
+
+        except ValueError as ve:
+            messagebox.showerror("Validation Error", f"Invalid number format for one of the fields: {ve}")
+            return
+        except Exception as ex:
+            messagebox.showerror("Error", f"An unexpected error occurred: {ex}")
+            return
+
+        # Save to CSV
+        csv_filename = "Fe_materials_dataset.csv"
+        file_exists = os.path.isfile(csv_filename)
+
+        try:
+            with open(csv_filename, 'a', newline='') as csvfile:
+                writer = csv.DictWriter(csvfile, fieldnames=CSV_HEADERS)
+                if not file_exists or os.path.getsize(csv_filename) == 0:
+                    writer.writeheader() # Write header if file is new or empty
+
+                # Ensure all CSV_HEADERS are present in data_row, fill with empty string if not
+                for header_key in CSV_HEADERS:
+                    if header_key not in data_row:
+                        data_row[header_key] = ''
+                writer.writerow(data_row)
+            messagebox.showinfo("Success", f"Data for {material_id} saved to {csv_filename}")
+            self.clear_manual_entry_fields() # Optionally clear after successful save
+        except Exception as e:
+            messagebox.showerror("CSV Write Error", f"Could not save data to CSV: {e}")
+
+
+    def clear_manual_entry_fields(self):
+        for key, widget in self.manual_entry_fields.items():
+            if isinstance(widget, ttk.Combobox):
+                if "N/A" in widget['values']: widget.set("N/A") # Corrected widgetc to widget
+                else: widget.set('') # Or set to first option if that's preferred
+            else: # Entry widgets
+                widget.delete(0, tk.END)
+        self.manual_cif_path_label.config(text="No CIF file loaded.")
+        self.selected_manual_cif_path.set("")
+
+
+    # --- Methods for Prediction Tab (slight refactor for clarity) ---
+    def select_file_for_prediction(self):
         file_path = filedialog.askopenfilename(
             defaultextension=".cif",
             filetypes=[("CIF files", "*.cif"), ("All files", "*.*")]
         )
         if file_path:
             self.selected_file_path = file_path
-            self.file_label.config(text=self.selected_file_path)
+            self.file_label.config(text=os.path.basename(file_path))
+            self.clear_prediction_labels() # Clear old predictions
         else:
             self.selected_file_path = ""
             self.file_label.config(text="No file selected")
-            self.clear_predictions()
+            self.clear_prediction_labels()
 
-    def clear_predictions(self):
-        self.band_gap_label_value.config(text="N/A")
-        self.dos_label_value.config(text="N/A")
-        self.formation_energy_label_value.config(text="N/A")
+    def clear_prediction_labels(self):
+        # Pymatgen derived
         self.formula_label_value.config(text="N/A")
         self.density_label_value.config(text="N/A")
         self.volume_label_value.config(text="N/A")
+        # Model predictions
+        self.model_is_metal_label.config(text="N/A")
+        self.model_band_gap_label.config(text="N/A")
+        self.model_formation_energy_label.config(text="N/A")
+        self.model_dos_at_fermi_label.config(text="N/A")
+
 
     def perform_prediction(self):
-        # messagebox is imported at the top of the file.
-        if not self.selected_file_path:
-            messagebox.showinfo("No File Selected", "Please select a CIF file first.")
-            self.clear_predictions()
+        if not self.selected_file_path or not hasattr(self, 'preprocessor_main'): # Check if preprocessor loaded
+            messagebox.showinfo("Setup Incomplete", "Please select a CIF file and ensure models are loaded.")
+            self.clear_prediction_labels()
             return
 
-        # CIF Parsing Block
         try:
-            self.current_structure = Structure.from_file(self.selected_file_path)
-            self.extracted_formula = self.current_structure.formula
-            # Format density and volume to a few decimal places
-            self.extracted_density = f"{self.current_structure.density:.4f} g/cm³"
-            self.extracted_volume = f"{self.current_structure.volume:.4f} Å³"
+            s = Structure.from_file(self.selected_file_path)
+            self.current_structure = s # Store for potential later use, though direct features are used below
 
-            # Update GUI labels for CIF properties immediately after successful parsing
-            self.formula_label_value.config(text=self.extracted_formula)
-            self.density_label_value.config(text=self.extracted_density)
-            self.volume_label_value.config(text=self.extracted_volume)
+            # Update Pymatgen-derived feature labels
+            self.formula_label_value.config(text=s.composition.reduced_formula)
+            self.density_label_value.config(text=f"{s.density:.4f} g/cm³")
+            self.volume_label_value.config(text=f"{s.volume:.4f} Å³")
 
+            # Prepare data for model prediction (single row DataFrame)
+            # Must match features used in train_model.py for preprocessor_main
+            feature_data = {
+                'num_elements': len(s.composition.elements),
+                'density_pg': s.density,
+                'volume_pg': s.volume,
+                'volume_per_atom_pg': s.volume / s.num_sites,
+                'spacegroup_number_pg': s.get_space_group_info()[1],
+                'lattice_a_pg': s.lattice.a,
+                'lattice_b_pg': s.lattice.b,
+                'lattice_c_pg': s.lattice.c,
+                'lattice_alpha_pg': s.lattice.alpha,
+                'lattice_beta_pg': s.lattice.beta,
+                'lattice_gamma_pg': s.lattice.gamma,
+                'num_sites_pg': s.num_sites,
+                'elements': ','.join(sorted([el.symbol for el in s.composition.elements])),
+                'crystal_system_pg': s.get_crystal_system().lower(),
+                # The 'band_gap_mp' and 'formation_energy_per_atom_mp' were features in training
+                # but they are what we predict or similar to. For a pure CIF prediction,
+                # these would not be available as inputs.
+                # We should use only pymatgen derivable features for prediction from CIF.
+                # The training script's numerical_features_main needs to be consistent.
+                # Assuming for now these _mp features are NOT used by preprocessor_main for CIF-only prediction.
+            }
+
+            # Define numerical and categorical features exactly as in train_model.py for main models
+            # These are the features the preprocessor_main was trained on.
+            numerical_features_for_main_pred = [
+                'num_elements', 'density_pg', 'volume_pg', 'volume_per_atom_pg',
+                'spacegroup_number_pg', 'lattice_a_pg', 'lattice_b_pg', 'lattice_c_pg',
+                'lattice_alpha_pg', 'lattice_beta_pg', 'lattice_gamma_pg', 'num_sites_pg'
+            ] # These should NOT include band_gap_mp or formation_energy_per_atom_mp if predicting from CIF alone
+            categorical_features_for_main_pred = ['elements', 'crystal_system_pg']
+
+            df_predict = pd.DataFrame([feature_data], columns=numerical_features_for_main_pred + categorical_features_for_main_pred)
+
+            predicted_is_metal = None # To guide DOS prediction
+
+            # Predict is_metal
+            if self.preprocessor_main and self.model_is_metal:
+                try:
+                    processed_data_main = self.preprocessor_main.transform(df_predict)
+                    pred_is_metal_val = self.model_is_metal.predict(processed_data_main)[0]
+                    pred_is_metal_proba = self.model_is_metal.predict_proba(processed_data_main)[0]
+                    predicted_is_metal = bool(pred_is_metal_val)
+                    self.model_is_metal_label.config(text=f"{predicted_is_metal} (Prob: {pred_is_metal_proba[pred_is_metal_val]:.2f})")
+                except Exception as e:
+                    self.model_is_metal_label.config(text="Error")
+                    warnings.warn(f"Error predicting is_metal: {e}")
+            else:
+                self.model_is_metal_label.config(text="N/A (model not loaded)")
+
+            # Predict band_gap
+            if self.preprocessor_main and self.model_band_gap:
+                try:
+                    # processed_data_main would have been computed during 'is_metal' prediction if models loaded.
+                    # Recompute or ensure it's available if 'is_metal' part was skipped.
+                    if not 'processed_data_main' in locals() and self.preprocessor_main: # Check if it exists in local scope
+                         processed_data_main = self.preprocessor_main.transform(df_predict)
+
+                    pred_band_gap = self.model_band_gap.predict(processed_data_main)[0]
+                    self.model_band_gap_label.config(text=f"{pred_band_gap:.3f} eV")
+                except Exception as e:
+                    self.model_band_gap_label.config(text="Error")
+                    warnings.warn(f"Error predicting band_gap: {e}")
+            else:
+                self.model_band_gap_label.config(text="N/A (model not loaded)")
+
+            # Predict formation_energy
+            if self.preprocessor_main and self.model_formation_energy:
+                try:
+                    # Ensure processed_data_main is available
+                    if not 'processed_data_main' in locals() and self.preprocessor_main:
+                         processed_data_main = self.preprocessor_main.transform(df_predict)
+
+                    pred_form_energy = self.model_formation_energy.predict(processed_data_main)[0]
+                    self.model_formation_energy_label.config(text=f"{pred_form_energy:.3f} eV/atom")
+                except Exception as e:
+                    self.model_formation_energy_label.config(text="Error")
+                    warnings.warn(f"Error predicting formation_energy: {e}")
+            else:
+                self.model_formation_energy_label.config(text="N/A (model not loaded)")
+
+            # Predict dos_at_fermi (only if predicted as metal and models are available)
+            if predicted_is_metal is True and self.preprocessor_dos and self.model_dos_at_fermi:
+                 # Features for DOS model (must match training)
+                numerical_features_for_dos_pred = [
+                    'num_elements', 'density_pg', 'volume_pg', 'volume_per_atom_pg',
+                    'spacegroup_number_pg', 'lattice_a_pg', 'lattice_b_pg', 'lattice_c_pg',
+                    'lattice_alpha_pg', 'lattice_beta_pg', 'lattice_gamma_pg', 'num_sites_pg'
+                    # Crucially, these must be the same features preprocessor_dos was trained on.
+                    # If band_gap_mp or formation_energy_mp were part of its training features,
+                    # they are not available here. This implies preprocessor_dos and model_dos_at_fermi
+                    # should have been trained *without* them if predicting from pure CIF.
+                    # For now, assume they are consistent with features_for_main_pred.
+                ]
+                df_predict_dos = pd.DataFrame([feature_data], columns=numerical_features_for_dos_pred + categorical_features_for_main_pred)
+                try:
+                    processed_data_dos = self.preprocessor_dos.transform(df_predict_dos)
+                    pred_dos_val = self.model_dos_at_fermi.predict(processed_data_dos)[0]
+                    self.model_dos_at_fermi_label.config(text=f"{pred_dos_val:.3f} eV⁻¹")
+                except Exception as e:
+                    self.model_dos_at_fermi_label.config(text="Error")
+                    warnings.warn(f"Error predicting dos_at_fermi: {e}")
+            elif predicted_is_metal is False:
+                 self.model_dos_at_fermi_label.config(text="N/A (predicted non-metal)")
+            else:
+                self.model_dos_at_fermi_label.config(text="N/A (model/preprocessor error or not metal)")
+
+        except FileNotFoundError:
+            messagebox.showerror("CIF Error", "CIF file not found at the selected path.")
+            self.clear_prediction_labels()
         except Exception as e:
-            messagebox.showerror("CIF Parsing Error", f"Could not read CIF file: {e}")
-            self.current_structure = None
-            self.extracted_formula = "Error"
-            self.extracted_density = "Error"
-            self.extracted_volume = "Error"
-            # Update GUI labels to show error state
-            self.formula_label_value.config(text=self.extracted_formula)
-            self.density_label_value.config(text=self.extracted_density)
-            self.volume_label_value.config(text=self.extracted_volume)
-            # Clear other prediction labels as well
-            self.band_gap_label_value.config(text="N/A")
-            self.dos_label_value.config(text="N/A")
-            self.formation_energy_label_value.config(text="N/A")
-            return # Stop further processing if CIF parsing fails
-
-        # Proceed with placeholder predictions ONLY if CIF parsing was successful
-        predictions = self.get_placeholder_predictions(self.current_structure) # Pass the structure object
-
-        self.band_gap_label_value.config(text=predictions.get("band_gap", "N/A"))
-        self.dos_label_value.config(text=predictions.get("dos", "N/A"))
-        self.formation_energy_label_value.config(text=predictions.get("formation_energy", "N/A"))
+            messagebox.showerror("Prediction Error", f"Could not perform prediction: {e}")
+            self.clear_prediction_labels()
+            # Also clear pymatgen derived features if structure parsing itself failed
+            self.formula_label_value.config(text="Error")
+            self.density_label_value.config(text="Error")
+            self.volume_label_value.config(text="Error")
 
 
-    def get_placeholder_predictions(self, structure): # Argument changed to structure
-        if structure is None:
-            return {"band_gap": "N/A", "dos": "N/A", "formation_energy": "N/A"}
+    # Placeholder get_placeholder_predictions removed as it's no longer used by perform_prediction
+    # def get_placeholder_predictions(self, structure): ...
 
-        # Use reduced formula for lookup
-        formula = structure.composition.reduced_formula
-
-        placeholder_data = {
-            "Si": {"band_gap": "1.1 eV", "dos": "Si_dos.png", "formation_energy": "0 eV/atom"},
-            "GaAs": {"band_gap": "1.4 eV", "dos": "GaAs_dos.png", "formation_energy": "-0.7 eV/atom"},
-            "NaCl": {"band_gap": "8.5 eV", "dos": "NaCl_dos.png", "formation_energy": "-3.0 eV/atom"},
-            "CsPbI3": {"band_gap": "1.9 eV", "dos": "CsPbI3_dos.png", "formation_energy": "-0.9 eV/atom"}
-            # Example: CsPbI3 formation energy updated slightly
-        }
-
-        if formula in placeholder_data:
-            return placeholder_data[formula]
-        else:
-            return {"band_gap": "N/A", "dos": "N/A", "formation_energy": "N/A"}
 
 if __name__ == '__main__':
     app = Application()

--- a/process_raw_data.py
+++ b/process_raw_data.py
@@ -1,0 +1,165 @@
+import json
+import csv
+import warnings
+import os # For checking file existence
+
+from pymatgen.core.structure import Structure
+from pymatgen.electronic_structure.dos import Dos # To reconstruct DOS objects
+
+# Re-define or import DATA_SCHEMA (ensure it's identical to the one in fetch_mp_data.py)
+# For simplicity in this step, we'll redefine it here.
+# In a larger project, this might be in a shared 'config.py' or 'schema.py'.
+DATA_SCHEMA = {
+    "material_id": "Materials Project ID (e.g., mp-123)",
+    "cif_string": "Crystallographic Information File as a string", # Will not be in final CSV
+    # Features from Materials Project API
+    "band_gap_mp": "Band Gap (eV) directly from MP",
+    "formation_energy_per_atom_mp": "Formation Energy (eV/atom) directly from MP",
+    "dos_object_mp": "The CompleteDOS object from MP (temporary, for processing)", # Will not be in final CSV
+    # Processed DOS Features
+    "is_metal": "Boolean (True if band_gap_mp == 0, False otherwise)",
+    "dos_at_fermi": "Value of total DOS at Fermi level (eV⁻¹). 0 or N/A for insulators.",
+    # Features to be extracted by Pymatgen from CIF string
+    "formula_pretty": "Reduced chemical formula (e.g., 'Si', 'GaAs')",
+    "num_elements": "Number of distinct elements in the material",
+    "elements": "Comma-separated string of elements (e.g., 'Ga,As')",
+    "density_pg": "Density (g/cm³) calculated by pymatgen",
+    "volume_pg": "Cell Volume (Å³) calculated by pymatgen",
+    "volume_per_atom_pg": "Volume per atom (Å³/atom) calculated by pymatgen",
+    "spacegroup_number_pg": "Space Group Number calculated by pymatgen",
+    "crystal_system_pg": "Crystal System (e.g., 'cubic', 'tetragonal') from pymatgen",
+    "lattice_a_pg": "Lattice parameter a (Å)",
+    "lattice_b_pg": "Lattice parameter b (Å)",
+    "lattice_c_pg": "Lattice parameter c (Å)",
+    "lattice_alpha_pg": "Lattice angle alpha (°)",
+    "lattice_beta_pg": "Lattice angle beta (°)",
+    "lattice_gamma_pg": "Lattice angle gamma (°)",
+    "num_sites_pg": "Number of atomic sites in the unit cell from pymatgen",
+    # Target properties
+    "target_band_gap": "Final Band Gap (eV) for ML",
+    "target_formation_energy": "Final Formation Energy (eV/atom) for ML",
+    "target_is_metal": "Final 'is_metal' boolean for ML",
+    "target_dos_at_fermi": "Final 'dos_at_fermi' for ML"
+}
+
+
+def process_data():
+    """
+    Loads raw data from mp_raw_data.json, processes it,
+    and saves it to Fe_materials_dataset.csv.
+    """
+    raw_data_filename = "mp_raw_data.json"
+    if not os.path.exists(raw_data_filename):
+        print(f"Error: Raw data file '{raw_data_filename}' not found. Please run fetch_mp_data.py first.")
+        return
+
+    with open(raw_data_filename, 'r') as f:
+        raw_materials_data = json.load(f)
+
+    processed_materials_data = []
+    print(f"Starting processing for {len(raw_materials_data)} raw material entries...")
+
+    for i, raw_material_doc in enumerate(raw_materials_data):
+        material_id = raw_material_doc.get('material_id', f"unknown_id_{i}")
+        print(f"Processing material: {material_id} ({i+1}/{len(raw_materials_data)})")
+
+        processed_doc = {'material_id': material_id}
+
+        # --- Pymatgen Feature Extraction ---
+        cif_string = raw_material_doc.get('cif_string')
+        if cif_string:
+            try:
+                struct = Structure.from_str(cif_string, fmt="cif")
+
+                processed_doc['formula_pretty'] = struct.composition.reduced_formula
+                processed_doc['num_elements'] = len(struct.composition.elements)
+                processed_doc['elements'] = ','.join(sorted([el.symbol for el in struct.composition.elements]))
+                processed_doc['density_pg'] = struct.density
+                processed_doc['volume_pg'] = struct.volume
+                processed_doc['volume_per_atom_pg'] = struct.volume / struct.num_sites
+                processed_doc['spacegroup_number_pg'] = struct.get_space_group_info()[1] # (symbol, number)
+                processed_doc['crystal_system_pg'] = struct.get_crystal_system()
+
+                lat = struct.lattice
+                processed_doc['lattice_a_pg'] = lat.a
+                processed_doc['lattice_b_pg'] = lat.b
+                processed_doc['lattice_c_pg'] = lat.c
+                processed_doc['lattice_alpha_pg'] = lat.alpha
+                processed_doc['lattice_beta_pg'] = lat.beta
+                processed_doc['lattice_gamma_pg'] = lat.gamma
+                processed_doc['num_sites_pg'] = struct.num_sites
+
+            except Exception as e:
+                warnings.warn(f"Pymatgen parsing/feature extraction failed for {material_id}: {e}")
+                # Fill relevant pymatgen features with None or N/A if parsing fails
+                pg_features = [k for k in DATA_SCHEMA if k.endswith('_pg') or k in ["formula_pretty", "num_elements", "elements"]]
+                for feat in pg_features:
+                    processed_doc[feat] = None
+        else:
+            warnings.warn(f"CIF string missing for {material_id}.")
+            pg_features = [k for k in DATA_SCHEMA if k.endswith('_pg') or k in ["formula_pretty", "num_elements", "elements"]]
+            for feat in pg_features:
+                processed_doc[feat] = None
+
+        # --- Process MP Features and DOS ---
+        band_gap_mp = raw_material_doc.get('band_gap_mp')
+        processed_doc['band_gap_mp'] = band_gap_mp
+        processed_doc['formation_energy_per_atom_mp'] = raw_material_doc.get('formation_energy_per_atom_mp')
+
+        if band_gap_mp is not None:
+            processed_doc['is_metal'] = (band_gap_mp == 0.0)
+        else:
+            processed_doc['is_metal'] = None
+
+        dos_dict = raw_material_doc.get('dos_object_mp')
+        processed_doc['dos_at_fermi'] = None # Default to None
+        if dos_dict:
+            try:
+                pymatgen_dos = Dos.from_dict(dos_dict)
+                # Check if efermi is present and valid before calculating DOS at Fermi
+                if pymatgen_dos.efermi is not None:
+                    # Ensure Fermi level is within the energy range of the DOS plot
+                    min_energy = min(pymatgen_dos.energies)
+                    max_energy = max(pymatgen_dos.energies)
+                    if min_energy <= pymatgen_dos.efermi <= max_energy:
+                        dos_val = pymatgen_dos.get_dos_at_fermi()
+                        # get_dos_at_fermi() might return a small list if multiple spin channels, sum them for total DOS
+                        processed_doc['dos_at_fermi'] = sum(dos_val) if isinstance(dos_val, list) else dos_val
+                    else:
+                        warnings.warn(f"Fermi level {pymatgen_dos.efermi} for {material_id} is outside DOS energy range [{min_energy}, {max_energy}]. Setting dos_at_fermi to 0.")
+                        processed_doc['dos_at_fermi'] = 0.0 # Or None, depending on desired handling
+                else:
+                     warnings.warn(f"Fermi level not found in DOS object for {material_id}. Cannot calculate dos_at_fermi.")
+            except Exception as e:
+                warnings.warn(f"DOS processing failed for {material_id}: {e}")
+
+        # --- Set Target Columns ---
+        processed_doc['target_band_gap'] = processed_doc.get('band_gap_mp')
+        processed_doc['target_formation_energy'] = processed_doc.get('formation_energy_per_atom_mp')
+        processed_doc['target_is_metal'] = processed_doc.get('is_metal')
+        processed_doc['target_dos_at_fermi'] = processed_doc.get('dos_at_fermi')
+
+        processed_materials_data.append(processed_doc)
+
+    # --- Write to CSV ---
+    # Define CSV fieldnames - ensure order and exclude non-CSV fields
+    csv_fieldnames = [key for key in DATA_SCHEMA.keys() if key not in ['cif_string', 'dos_object_mp']]
+
+    # Ensure all keys in processed_doc are in csv_fieldnames, add if any are missing (e.g. due to dynamic keys)
+    # However, it's better to strictly adhere to DATA_SCHEMA for CSV columns.
+    # For this implementation, we assume processed_doc keys will be a subset of DATA_SCHEMA keys intended for CSV.
+
+    csv_filename = "Fe_materials_dataset.csv"
+    print(f"\nWriting processed data to {csv_filename}...")
+    try:
+        with open(csv_filename, 'w', newline='') as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=csv_fieldnames, extrasaction='ignore') # extrasaction='ignore' is safer
+            writer.writeheader()
+            for row_data in processed_materials_data:
+                writer.writerow(row_data)
+        print(f"Successfully processed and saved data for {len(processed_materials_data)} materials to {csv_filename}.")
+    except Exception as e:
+        print(f"Error writing to CSV: {e}")
+
+if __name__ == "__main__":
+    process_data()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pymatgen
+mp-api

--- a/train_model.py
+++ b/train_model.py
@@ -1,0 +1,208 @@
+import pandas as pd
+import numpy as np
+import json
+import joblib
+import os
+
+from sklearn.model_selection import train_test_split
+from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier
+from sklearn.metrics import mean_absolute_error, r2_score, accuracy_score, f1_score
+from sklearn.preprocessing import StandardScaler, OneHotEncoder
+from sklearn.compose import ColumnTransformer
+from sklearn.pipeline import Pipeline
+from sklearn.impute import SimpleImputer
+
+# Attempt to import DATA_SCHEMA or define relevant parts for feature identification
+# For simplicity in this standalone script, we'll manually define feature lists.
+# In a real project, this might come from a shared config or by loading fetch_mp_data.py schema.
+
+def train_models():
+    """
+    Loads data, preprocesses it, and trains separate models for various material properties.
+    """
+    csv_file = 'Fe_materials_dataset.csv'
+    if not os.path.exists(csv_file):
+        print(f"Error: Dataset file '{csv_file}' not found. Please generate it first.")
+        return
+
+    df = pd.read_csv(csv_file)
+    if df.empty:
+        print("Error: Dataset is empty.")
+        return
+
+    print(f"Loaded dataset with {df.shape[0]} rows and {df.shape[1]} columns.")
+
+    # --- Define Features and Targets ---
+    target_columns_reg = ['target_band_gap', 'target_formation_energy', 'target_dos_at_fermi']
+    target_column_clf = 'target_is_metal'
+
+    # Based on DATA_SCHEMA from fetch_mp_data.py (manually transcribed for this script)
+    categorical_features = ['elements', 'crystal_system_pg']
+
+    numerical_features = [
+        'band_gap_mp', 'formation_energy_per_atom_mp', # These are also targets, but can be features if not the current target
+        # Pymatgen derived features:
+        'num_elements', 'density_pg', 'volume_pg', 'volume_per_atom_pg',
+        'spacegroup_number_pg', 'lattice_a_pg', 'lattice_b_pg', 'lattice_c_pg',
+        'lattice_alpha_pg', 'lattice_beta_pg', 'lattice_gamma_pg', 'num_sites_pg'
+    ]
+    # Exclude material_id and direct target columns from features when training for that target.
+    # 'dos_at_fermi' (from _mp) is handled specially for its own model.
+
+    # --- Preprocessing Setup ---
+    numerical_transformer = Pipeline(steps=[
+        ('imputer', SimpleImputer(strategy='mean')),
+        ('scaler', StandardScaler())
+    ])
+
+    categorical_transformer = Pipeline(steps=[
+        ('imputer', SimpleImputer(strategy='most_frequent')),
+        ('onehot', OneHotEncoder(handle_unknown='ignore', sparse_output=False))
+    ])
+
+    # This preprocessor will be fitted specifically for each model or dataset subset
+    # General preprocessor definition (to be cloned or refitted)
+    preprocessor_base = ColumnTransformer(
+        transformers=[
+            ('num', numerical_transformer, numerical_features),
+            ('cat', categorical_transformer, categorical_features)
+        ],
+        remainder='passthrough' # Keep other columns (like material_id) if X includes them, or 'drop'
+    )
+
+    # --- Train Regressor for target_dos_at_fermi (Metals Only) ---
+    print("\n--- Training Model for DOS at Fermi (Metals Only) ---")
+    df_dos = df[df['target_is_metal'] == True].copy()
+    df_dos.dropna(subset=['target_dos_at_fermi'], inplace=True)
+
+    if not df_dos.empty:
+        # Features for DOS model (exclude target_dos_at_fermi if it's in numerical_features)
+        numerical_features_dos = [f for f in numerical_features if f != 'target_dos_at_fermi' and f != 'dos_at_fermi']
+
+        # Ensure 'is_metal' is not a feature for predicting 'dos_at_fermi' among metals
+        if 'is_metal' in numerical_features_dos: numerical_features_dos.remove('is_metal')
+        if 'is_metal' in categorical_features: categorical_features.remove('is_metal')
+
+
+        X_dos = df_dos[numerical_features_dos + categorical_features]
+        y_dos = df_dos['target_dos_at_fermi']
+
+        if X_dos.empty or y_dos.empty:
+            print("Not enough data to train DOS at Fermi model after filtering.")
+        else:
+            X_dos_train, X_dos_test, y_dos_train, y_dos_test = train_test_split(X_dos, y_dos, test_size=0.2, random_state=42)
+
+            # Fit a new preprocessor specifically for this dataset subset
+            preprocessor_dos = ColumnTransformer(
+                transformers=[
+                    ('num', numerical_transformer, numerical_features_dos),
+                    ('cat', categorical_transformer, categorical_features)
+                ], remainder='drop'
+            )
+
+            pipeline_dos = Pipeline(steps=[
+                ('preprocessor', preprocessor_dos),
+                ('regressor', RandomForestRegressor(random_state=42, n_estimators=10)) # Use fewer estimators for small dataset
+            ])
+
+            print(f"Training DOS model on {X_dos_train.shape[0]} samples...")
+            pipeline_dos.fit(X_dos_train, y_dos_train)
+
+            # Evaluate
+            y_pred_dos = pipeline_dos.predict(X_dos_test)
+            mae_dos = mean_absolute_error(y_dos_test, y_pred_dos)
+            r2_dos = r2_score(y_dos_test, y_pred_dos)
+            print(f"DOS Model (Metals Only) - MAE: {mae_dos:.4f}, R2: {r2_dos:.4f}")
+
+            joblib.dump(pipeline_dos, 'model_dos_at_fermi.joblib')
+            print("Saved DOS model to model_dos_at_fermi.joblib")
+            # The preprocessor is part of the pipeline_dos, so saving it separately is optional
+            # if you always use the pipeline. If needed:
+            # joblib.dump(pipeline_dos.named_steps['preprocessor'], 'preprocessor_dos_at_fermi.joblib')
+
+    else:
+        print("No metallic samples with DOS data found to train the DOS model.")
+
+    # --- Prepare Data for Main Models ---
+    print("\n--- Preparing Data for Main Models (Band Gap, Formation Energy, Is Metal) ---")
+    df_main = df.copy()
+    # Drop rows where any of the primary targets are NaN
+    main_target_cols = ['target_band_gap', 'target_formation_energy', 'target_is_metal']
+    df_main.dropna(subset=main_target_cols, inplace=True)
+
+    if df_main.empty:
+        print("Error: No data available for main models after dropping NaNs in target columns.")
+        return
+
+    # Define features for main models (exclude all direct targets)
+    numerical_features_main = [f for f in numerical_features if f not in target_columns_reg and f not in [target_column_clf, 'dos_at_fermi']]
+
+    X_main = df_main[numerical_features_main + categorical_features]
+
+    # Fit the main preprocessor
+    preprocessor_main = ColumnTransformer(
+        transformers=[
+            ('num', numerical_transformer, numerical_features_main), # Use main numerical features
+            ('cat', categorical_transformer, categorical_features)
+        ], remainder='drop'
+    )
+    print(f"Fitting main preprocessor on {X_main.shape[0]} samples for main models...")
+    # We need a train split of X_main to fit this preprocessor properly before using it for multiple models
+    X_main_temp_train, _ = train_test_split(X_main, df_main[main_target_cols[0]], test_size=0.2, random_state=42) # Use any target for split
+    preprocessor_main_fitted = preprocessor_main.fit(X_main_temp_train)
+    joblib.dump(preprocessor_main_fitted, 'preprocessor_main.joblib')
+    print("Saved main preprocessor to preprocessor_main.joblib")
+
+    # --- Train Regressors (Band Gap, Formation Energy) ---
+    reg_targets_to_train = ['target_band_gap', 'target_formation_energy']
+    for target_name in reg_targets_to_train:
+        print(f"\n--- Training Regressor for {target_name} ---")
+        y_reg = df_main[target_name]
+
+        X_reg_train, X_reg_test, y_reg_train, y_reg_test = train_test_split(X_main, y_reg, test_size=0.2, random_state=42)
+
+        # Transform data using the already fitted main preprocessor
+        X_reg_train_processed = preprocessor_main_fitted.transform(X_reg_train)
+        X_reg_test_processed = preprocessor_main_fitted.transform(X_reg_test)
+
+        regressor_model = RandomForestRegressor(random_state=42, n_estimators=10) # Use fewer estimators for small dataset
+
+        print(f"Training {target_name} model on {X_reg_train_processed.shape[0]} samples...")
+        regressor_model.fit(X_reg_train_processed, y_reg_train)
+
+        y_pred_reg = regressor_model.predict(X_reg_test_processed)
+        mae_reg = mean_absolute_error(y_reg_test, y_pred_reg)
+        r2_reg = r2_score(y_reg_test, y_pred_reg)
+        print(f"{target_name} Model - MAE: {mae_reg:.4f}, R2: {r2_reg:.4f}")
+
+        joblib.dump(regressor_model, f'model_{target_name}.joblib')
+        print(f"Saved {target_name} model to model_{target_name}.joblib")
+
+    # --- Train Classifier (is_metal) ---
+    print(f"\n--- Training Classifier for {target_column_clf} ---")
+    y_clf = df_main[target_column_clf].astype(int) # Ensure boolean is int
+
+    # We can reuse X_main from the regression part if features are identical
+    X_clf_train, X_clf_test, y_clf_train, y_clf_test = train_test_split(X_main, y_clf, test_size=0.2, random_state=42)
+
+    # Transform data using the already fitted main preprocessor
+    X_clf_train_processed = preprocessor_main_fitted.transform(X_clf_train)
+    X_clf_test_processed = preprocessor_main_fitted.transform(X_clf_test)
+
+    classifier_model = RandomForestClassifier(random_state=42, n_estimators=10) # Use fewer estimators
+
+    print(f"Training {target_column_clf} model on {X_clf_train_processed.shape[0]} samples...")
+    classifier_model.fit(X_clf_train_processed, y_clf_train)
+
+    y_pred_clf = classifier_model.predict(X_clf_test_processed)
+    accuracy_clf = accuracy_score(y_clf_test, y_pred_clf)
+    f1_clf = f1_score(y_clf_test, y_pred_clf, average='weighted')
+    print(f"{target_column_clf} Model - Accuracy: {accuracy_clf:.4f}, F1 Score: {f1_clf:.4f}")
+
+    joblib.dump(classifier_model, f'model_{target_column_clf}.joblib')
+    print(f"Saved {target_column_clf} model to model_{target_column_clf}.joblib")
+
+    print("\n--- Model Training Completed ---")
+
+if __name__ == "__main__":
+    train_models()


### PR DESCRIPTION
This commit introduces a comprehensive machine learning pipeline for material property prediction, including:

1.  **Data Acquisition (Materials Project API):**
    *   `fetch_mp_data.py`: Script to fetch material data (CIFs, band gap, formation energy, DOS) for Fe-based compounds from the Materials Project API. Requires an `MP_API_KEY` environment variable. Saves raw data to `mp_raw_data.json`.
    *   `process_raw_data.py`: Processes the raw data, extracts pymatgen features, and compiles `Fe_materials_dataset.csv`.
    *   Includes a placeholder `Fe_materials_dataset.csv` for you if you don't have immediate API access or for testing.

2.  **Model Training:**
    *   `train_model.py`: Trains Random Forest models for:
        *   Band Gap (Regression)
        *   Formation Energy (Regression)
        *   Is Metal (Classification)
        *   DOS at Fermi (Regression, for metals)
    *   Performs preprocessing (scaling, encoding) and saves trained models and preprocessors as `.joblib` files.

3.  **GUI Enhancements (`material_predictor_gui.py`):**
    *   **Prediction Tab:** Now uses the trained ML models to predict properties from a CIF file you select. Handles missing models gracefully.
    *   **Manual Data Entry Tab:** New interface allowing you to:
        *   Manually input all material features and target properties.
        *   Optionally load a CIF to auto-fill pymatgen-derived features.
        *   Save new entries to `Fe_materials_dataset.csv`, enabling dataset augmentation or creation.
    *   GUI now uses a tabbed layout.

4.  **Documentation:**
    *   `README.md` and `README_pt.md` extensively updated to cover all new functionalities, scripts, API key requirements, and usage instructions for the entire workflow.

5.  **Dependencies:**
    *   `mp-api` added to `requirements.txt`.