### PR TITLE
Fix: Align default output filename of fetch_mp_data.py

### DIFF
--- a/scripts/fetch_mp_data.py
+++ b/scripts/fetch_mp_data.py
@@ -88,7 +88,7 @@ def fetch_data(max_total_materials_arg=50): # Renamed arg to avoid conflict with
     supercon_compositions_csv_path = fetch_config_params.get('supercon_processed_csv_path', "data/supercon_processed.csv") # Make path configurable
     target_compositions = get_supercon_compositions(supercon_compositions_csv_path)
 
-    output_filename = fetch_config_params.get('output_filename', "data/mp_raw_data_from_supercon.json") # Consider a new default output name
+    output_filename = fetch_config_params.get('output_filename', "data/mp_raw_data.json") # Consider a new default output name
     if not target_compositions:
         print("No target compositions loaded from CSV. Exiting.")
         # Ensure output JSON is empty or not written if no compositions


### PR DESCRIPTION
This commit changes the default output filename in `scripts/fetch_mp_data.py` from "data/mp_raw_data_from_supercon.json" back to "data/mp_raw_data.json".

This change is to ensure that when `fetch_mp_data.py` is used in its new mode (fetching data based on compositions from `supercon_processed.csv`), its default output is named as expected by `scripts/process_raw_data.py`. This addresses a "File not found" error that could occur when running `process_raw_data.py` after `fetch_mp_data.py` if the output filename was not explicitly configured to match.

The output filename can still be overridden via the `output_filename` parameter in the `fetch_data` section of `config.yml`.