### PR TITLE
Fix: Update process_raw_data.py to handle new input format

### DIFF
--- a/tests/mp_raw_data_sample.json
+++ b/tests/mp_raw_data_sample.json
@@ -1,0 +1,51 @@
+{
+  "ValidEntryCu": {
+    "material_id": "mp-123",
+    "cif_string_mp": "CIF_STRING_FOR_Cu",
+    "band_gap": 1.0,
+    "formation_energy_per_atom": -0.5,
+    "dos_object_mp": {
+      "efermi": 0.0,
+      "energies": [-1.0, 0.0, 1.0],
+      "densities": {"1": [0.1, 0.2, 0.3]},
+      "@module": "pymatgen.electronic_structure.dos",
+      "@class": "CompleteDos"
+    },
+    "some_other_mp_field": "value1"
+  },
+  "NoneEntryFe": null,
+  "MissingCifBaKFeAs": {
+    "material_id": "mp-456",
+    "cif_string_mp": null,
+    "band_gap": 0.0,
+    "formation_energy_per_atom": -1.2,
+    "dos_object_mp": {
+      "efermi": 0.5,
+      "energies": [-0.5, 0.5, 1.5],
+      "densities": {"1": [0.4, 0.5, 0.6]},
+      "@module": "pymatgen.electronic_structure.dos",
+      "@class": "CompleteDos"
+    },
+    "another_field": "value2"
+  },
+  "MissingDosSi": {
+    "material_id": "mp-789",
+    "cif_string_mp": "CIF_STRING_FOR_Si",
+    "band_gap": 0.5,
+    "formation_energy_per_atom": -0.8,
+    "dos_object_mp": null,
+    "yet_another_field": "value3"
+  },
+  "ValidEntryNoMaterialId": {
+    "cif_string_mp": "CIF_STRING_FOR_NoMatId",
+    "band_gap": 0.1,
+    "formation_energy_per_atom": -0.2,
+    "dos_object_mp": {
+      "efermi": 0.0,
+      "energies": [-1.0, 0.0, 1.0],
+      "densities": {"1": [0.1, 0.2, 0.3]},
+      "@module": "pymatgen.electronic_structure.dos",
+      "@class": "CompleteDos"
+    }
+  }
+}

--- a/utils/schema.py
+++ b/utils/schema.py
@@ -4,6 +4,7 @@
 # and some derived properties. It's used as a reference in fetching and processing stages.
 DATA_SCHEMA = {
     "material_id": "Materials Project ID (e.g., mp-123)",
+    "supercon_composition": "Original SuperCon composition string (e.g., 'Ba0.6K0.4Fe2As2')",
     "cif_string": "Crystallographic Information File as a string",
     "band_gap_mp": "Band Gap (eV) directly from MP",
     "formation_energy_per_atom_mp": "Formation Energy (eV/atom) directly from MP",


### PR DESCRIPTION
I've updated the script `scripts/process_raw_data.py` to correctly process the JSON output generated by `scripts/fetch_mp_data.py`.

Key changes:

1.  **Input Handling:**
    *   `process_raw_data.py` now expects the input JSON (`mp_raw_data.json`) to be a dictionary where keys are SuperCon composition strings and values are material data objects (or None).
    *   The script iterates through the values of this dictionary, skipping any `None` entries.

2.  **Field Key Updates:**
    *   The script now uses the correct key names to access data from the input, aligning with `fetch_mp_data.py`'s output:
        *   `cif_string_mp` (instead of `cif_string`)
        *   `band_gap` (instead of `band_gap_mp`)
        *   `formation_energy_per_atom` (instead of `formation_energy_per_atom_mp`)
    *   Note: The script continues to populate `band_gap_mp` and `formation_energy_per_atom_mp` in its internal `processed_doc` and the output CSV for schema consistency.

3.  **New Field `supercon_composition`:**
    *   The original SuperCon composition string (the key from the input JSON dictionary) is now added to the processed data as `supercon_composition`.
    *   `utils/schema.py` has been updated to include `supercon_composition` in `DATA_SCHEMA`. This field is now also part of the output CSV.

4.  **Testing:**
    *   I've added a new test case, `test_process_data_with_new_format`, to `tests/test_process_raw_data.py`.
    *   This test covers the new dictionary-based input format, the handling of the `supercon_composition` field, and various data scenarios including valid entries, None entries, and entries with missing CIF or DOS information.
    *   I also created a sample input file `tests/mp_raw_data_sample.json` (though the test primarily uses an inline dictionary for better self-containment).

These changes ensure that `process_raw_data.py` can correctly consume and process the data produced by `fetch_mp_data.py`.